### PR TITLE
fix jupyter detection and ensure curl availability

### DIFF
--- a/modules/01_jupyter.sh
+++ b/modules/01_jupyter.sh
@@ -27,7 +27,7 @@ PY
 }
 
 is_jupyter_running() {
-  pgrep -af "jupyter-lab.*--port=${JUPYTER_PORT}" >/dev/null 2>&1
+  pgrep -af "jupyter-lab.*--port[= ]${JUPYTER_PORT}" >/dev/null 2>&1
 }
 
 start_jupyter() {
@@ -50,5 +50,8 @@ start_jupyter() {
 
 ensure_python_tools
 install_jupyter_if_needed
+if command -v pyenv >/dev/null 2>&1; then
+  pyenv rehash
+fi
 start_jupyter
 

--- a/start.sh
+++ b/start.sh
@@ -22,7 +22,7 @@ run_module() {
 
 echo "[bootstrap] installing prerequisites..."
 pip install --upgrade huggingface_hub
-apt-get update && apt-get install -y git aria2 unzip
+apt-get update && apt-get install -y git aria2 unzip curl
 
 run_module "01_jupyter.sh"
 run_module "02_workspace.sh"


### PR DESCRIPTION
## Summary
- add curl to bootstrap prerequisites
- handle spaced or equals form of `--port` when detecting running Jupyter and rehash pyenv after installs

## Testing
- `bash -n start.sh modules/01_jupyter.sh`
- `REPO_DIR=/tmp/nomodules ./start.sh`
- `JUPYTER_PORT=9999 JUPYTER_TOKEN=test ./modules/01_jupyter.sh` (run twice)


------
https://chatgpt.com/codex/tasks/task_e_68a10034b354832cb906136bf5af1157