### PR TITLE
Clone ComfyUI during bootstrap for official RunPod image

### DIFF
--- a/modules/03_custom_nodes.sh
+++ b/modules/03_custom_nodes.sh
@@ -6,10 +6,9 @@ COMFY_DIR="${WORKDIR}/ComfyUI"
 NODES_DIR="${COMFY_DIR}/custom_nodes"
 CFG_FILE="${WORKDIR}/runpod-comfy-bootstrap/config/custom_nodes.txt"
 
-# ComfyUI repository
 if [ ! -d "${COMFY_DIR}/.git" ]; then
-  echo "[nodes] cloning ComfyUI..."
-  git clone https://github.com/comfyanonymous/ComfyUI.git "${COMFY_DIR}"
+  echo "[nodes] ComfyUI not found in ${COMFY_DIR}" >&2
+  exit 1
 fi
 
 # ComfyUI-Manager

--- a/start.sh
+++ b/start.sh
@@ -24,6 +24,15 @@ echo "[bootstrap] installing prerequisites..."
 pip install --upgrade huggingface_hub
 apt-get update && apt-get install -y git aria2 unzip curl
 
+# Ensure ComfyUI repository exists
+COMFY_DIR="${WORKDIR}/ComfyUI"
+if [ ! -d "${COMFY_DIR}/.git" ]; then
+  echo "[bootstrap] cloning ComfyUI..."
+  git clone https://github.com/comfyanonymous/ComfyUI.git "${COMFY_DIR}"
+else
+  echo "[bootstrap] ComfyUI already present"
+fi
+
 run_module "01_jupyter.sh"
 run_module "02_workspace.sh"
 run_module "03_custom_nodes.sh"


### PR DESCRIPTION
## Summary
- Clone ComfyUI in the bootstrap script when not already present
- Expect existing ComfyUI repo in custom nodes setup and fail early if missing

## Testing
- `bash -n start.sh modules/03_custom_nodes.sh`
- `shellcheck start.sh modules/03_custom_nodes.sh` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a102986350832cbcb98ff16492518f