### PR TITLE
Ensure startup script installs required OS tools

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -21,8 +21,9 @@ run_module() {
 }
 
 echo "[bootstrap] installing prerequisites..."
-pip install --upgrade huggingface_hub
-apt-get update && apt-get install -y git aria2 unzip curl
+export DEBIAN_FRONTEND=noninteractive
+apt-get update && apt-get install -y git aria2 unzip curl rsync procps
+python3 -m pip install --upgrade huggingface_hub
 
 # Ensure ComfyUI repository exists
 COMFY_DIR="${WORKDIR}/ComfyUI"


### PR DESCRIPTION
## Summary
- install git, aria2, unzip, curl, rsync and procps before running modules
- use non-interactive apt install and `python3 -m pip` for huggingface_hub

## Testing
- `shellcheck start.sh modules/01_jupyter.sh modules/02_workspace.sh modules/03_custom_nodes.sh modules/04_models.sh`


------
https://chatgpt.com/codex/tasks/task_e_68a1040b12d8832ca886da8a67e9c4e3