### PR TITLE
Ensure custom nodes install uses Python 3 pip

### DIFF
--- a/modules/03_custom_nodes.sh
+++ b/modules/03_custom_nodes.sh
@@ -40,8 +40,8 @@ fi
 
 # requirements
 echo "[nodes] installing Python dependencies..."
-pip install --upgrade pip wheel setuptools
-pip install -r "${COMFY_DIR}/requirements.txt" || true
+python3 -m pip install --upgrade pip wheel setuptools
+python3 -m pip install -r "${COMFY_DIR}/requirements.txt" || true
 for req in "${NODES_DIR}"/*/requirements.txt; do
-  [ -f "$req" ] && pip install -r "$req" || true
+  [ -f "$req" ] && python3 -m pip install -r "$req" || true
 done


### PR DESCRIPTION
## Summary
- call Python 3 explicitly for pip installs in custom nodes module

## Testing
- `bash -n start.sh modules/*.sh`

------
https://chatgpt.com/codex/tasks/task_e_68a10ec6ca18832caa131ee5f5ba868b