### PR TITLE
feat: improve bootstrap robustness and configurability

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ bash -lc 'cd /workspace && rm -rf runpod-comfy-bootstrap && \
 git clone https://github.com/SykkoAtHome/runpod-comfy-bootstrap.git && \
 bash runpod-comfy-bootstrap/start.sh && \
 cd /workspace/ComfyUI && \
-python main.py --listen 0.0.0.0 --port 8188'
+python main.py --listen 0.0.0.0 --port ${COMFY_PORT:-8188}'
 ```
 
 The command installs prerequisites, runs four modules, and then starts ComfyUI:

--- a/start.sh
+++ b/start.sh
@@ -1,20 +1,43 @@
 #!/usr/bin/env bash
 set -euo pipefail
+trap 'echo "[bootstrap] błąd w linii $LINENO"; exit 1' ERR
 
 WORKDIR="${WORKDIR:-/workspace}"
 REPO_DIR="${REPO_DIR:-${WORKDIR}/runpod-comfy-bootstrap}"
 LOGDIR="${LOGDIR:-${WORKDIR}/logs}"
 mkdir -p "$LOGDIR"
 
+export PIP_EXTRA_INDEX_URL="${PIP_EXTRA_INDEX_URL:-https://download.pytorch.org/whl/cu128}"
+
+if ! ping -c1 github.com >/dev/null 2>&1; then
+  echo "[bootstrap] WARNING: no internet connectivity"
+fi
+
 echo "[bootstrap] start (repo: $REPO_DIR)"
+
+retry() {
+  local n=0
+  local max=5
+  local delay=2
+  while true; do
+    "$@" && break
+    n=$((n+1))
+    if [ "$n" -ge "$max" ]; then
+      return 1
+    fi
+    echo "[retry] retry $n/$max: $*"
+    sleep "$delay"
+    delay=$((delay*2))
+  done
+}
 
 # Run modules safely
 run_module() {
   local m="$1"
   if [ -x "${REPO_DIR}/modules/${m}" ]; then
     echo "[bootstrap] >>> running module: ${m}"
-    "${REPO_DIR}/modules/${m}"
-    echo "[bootstrap] <<< module ${m} done"
+    bash "${REPO_DIR}/modules/${m}" >"${LOGDIR}/${m%.sh}.log" 2>&1
+    echo "[bootstrap] <<< module ${m} done (log: ${LOGDIR}/${m%.sh}.log)"
   else
     echo "[bootstrap] (skipped) missing module: ${m}"
   fi
@@ -22,14 +45,19 @@ run_module() {
 
 echo "[bootstrap] installing prerequisites..."
 export DEBIAN_FRONTEND=noninteractive
-apt-get update && apt-get install -y git aria2 unzip curl rsync procps
-python3 -m pip install --upgrade huggingface_hub
+if ! retry apt-get update; then
+  echo "[bootstrap] switching to mirror..."
+  sed -i 's|http://.*archive.ubuntu.com/ubuntu|mirror://mirrors.ubuntu.com/mirrors.txt|g; s|http://.*security.ubuntu.com/ubuntu|mirror://mirrors.ubuntu.com/mirrors.txt|g' /etc/apt/sources.list
+  retry apt-get update
+fi
+retry apt-get install -y git aria2 unzip curl rsync procps
+retry python3 -m pip install --upgrade huggingface_hub
 
 # Ensure ComfyUI repository exists
 COMFY_DIR="${WORKDIR}/ComfyUI"
 if [ ! -d "${COMFY_DIR}/.git" ]; then
   echo "[bootstrap] cloning ComfyUI..."
-  git clone https://github.com/comfyanonymous/ComfyUI.git "${COMFY_DIR}"
+  retry git clone --depth 1 https://github.com/comfyanonymous/ComfyUI.git "${COMFY_DIR}"
 else
   echo "[bootstrap] ComfyUI already present"
 fi


### PR DESCRIPTION
## Summary
- add retry, logging and shallow clones to bootstrap workflow
- gather and install custom-node requirements in one pip call
- validate HF_TOKEN and add mirror fallback for HuggingFace downloads

## Testing
- `bash -n start.sh modules/01_jupyter.sh modules/02_workspace.sh modules/03_custom_nodes.sh modules/04_models.sh`


------
https://chatgpt.com/codex/tasks/task_e_68a19201b3e4832ca0647daffb42f7a9