### PR TITLE
Add environment-controlled model downloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ The command installs prerequisites, runs four modules, and then starts ComfyUI:
 1. **Jupyter** – ensures JupyterLab is available and starts it on port 8888 using `python3 -m jupyterlab`; it's monitored with a simple HTTP health check.
 2. **Workspace** – prepares persistent directories and links them with ComfyUI. The `ComfyUI/models` directory is symlinked to `/workspace/models`, avoiding duplication.
 3. **Custom nodes** – clones listed custom nodes repositories. Some plugins automatically install extra dependencies such as `sageattention` and `onnxruntime`.
-4. **Models** – downloads models defined in `config/models.txt`.
+4. **Models** – downloads models defined in `config/models.txt`. Sections can be
+   toggled with environment variables like `download_wan2.1` or
+   `download_wan2.2` set to `True`/`False`.
 
 Edit `config/custom_nodes.txt` and `config/models.txt` to customize what gets installed.

--- a/config/models.txt
+++ b/config/models.txt
@@ -1,3 +1,6 @@
+# Model download list grouped by section.
+# Set environment variables `download_<section>` to "True" or "False"
+# to control downloads (e.g. `download_wan2.1=True`).
 # WAN2.1
 
 ## DIFFUSION


### PR DESCRIPTION
## Summary
- Allow selecting model downloads via `download_<section>` env vars
- Document environment variables in model config and README

## Testing
- `bash -n modules/04_models.sh`
- `env WORKDIR=/tmp/test 'download_wan2.1=False' 'download_wan2.2=False' bash modules/04_models.sh`


------
https://chatgpt.com/codex/tasks/task_e_68a1e7e13320832ca7aa5949a61885dc