### PR TITLE
Support nested model directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,12 +30,13 @@ Edit `config/custom_nodes.txt` and `config/models.yaml` to customize what gets i
 
 Models are listed in `config/models.yaml`, grouped by section. Each entry
 contains a `url` and a `target_dir` describing where the file should be stored.
-Example:
+The `target_dir` may include nested directories, which will be created
+automatically. Example:
 
 ```yaml
 wan2.1:
   - url: hf://owner/repo/path/to/model.safetensors
-    target_dir: diffusion_models
+    target_dir: diffusion_models/wan2.1
 ```
 
 Parsing the YAML requires [PyYAML](https://pyyaml.org); the bootstrap script

--- a/config/models.yaml
+++ b/config/models.yaml
@@ -6,7 +6,7 @@ wan2.1:
   - url: hf://Comfy-Org/Wan_2.1_ComfyUI_repackaged/split_files/diffusion_models/wan2.1_vace_14B_fp16.safetensors
     target_dir: diffusion_models
   - url: hf://Kijai/WanVideo_comfy/Phantom-Wan-14B_fp16.safetensors
-    target_dir: diffusion_models
+    target_dir: diffusion_models/wan2.1
   - url: hf://Kijai/WanVideo_comfy/Wan2_1-VACE_module_14B_bf16.safetensors
     target_dir: diffusion_models
   - url: hf://Comfy-Org/Wan_2.1_ComfyUI_repackaged/split_files/vae/wan_2.1_vae.safetensors

--- a/modules/04_models.sh
+++ b/modules/04_models.sh
@@ -77,6 +77,19 @@ mkdir -p "${MODELS_DIR}/diffusion_models" \
 
 if [ -f "$CFG_FILE" ]; then
   echo "[models] reading list from ${CFG_FILE}"
+  python3 - "$CFG_FILE" <<'PY' | while IFS= read -r dir; do
+import sys, yaml
+with open(sys.argv[1]) as f:
+    data = yaml.safe_load(f) or {}
+dirs = set()
+for items in data.values():
+    for item in items or []:
+        dirs.add(item.get('target_dir', 'diffusion_models'))
+for d in sorted(dirs):
+    print(d)
+PY
+    mkdir -p "${MODELS_DIR}/${dir}"
+  done
   while IFS=$'\t' read -r section url subdir; do
     var_name="$(echo "download_${section}" | tr '[:upper:]' '[:lower:]')"
     var_value="$(get_env "$var_name")"


### PR DESCRIPTION
## Summary
- create any target_dir from models.yaml before downloading
- document nested target_dir usage
- example config using a nested diffusion model directory

## Testing
- `shellcheck modules/04_models.sh` *(fails: command not found)*
- `bash -n modules/04_models.sh`

------
https://chatgpt.com/codex/tasks/task_e_68a1fc3cd848832c84bc9e207bbfb608