### PR TITLE
feat: support nested model configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,22 +21,27 @@ The command installs prerequisites, runs four modules, and then starts ComfyUI:
 2. **Workspace** – prepares persistent directories and links them with ComfyUI. The `ComfyUI/models` directory is symlinked to `/workspace/models`, avoiding duplication.
 3. **Custom nodes** – clones listed custom nodes repositories. Some plugins automatically install extra dependencies such as `sageattention` and `onnxruntime`.
 4. **Models** – downloads models defined in `config/models.yaml`. Sections can be
-   toggled with environment variables like `download_wan2.1` or
-   `download_wan2.2` set to `True`/`False`.
+   toggled with environment variables such as `download_wan2_1_diffusion_models`
+   or `download_text_encoders` set to `True`/`False`.
 
 Edit `config/custom_nodes.txt` and `config/models.yaml` to customize what gets installed.
 
 ### Model configuration
 
-Models are listed in `config/models.yaml`, grouped by section. Each entry
-contains a `url` and a `target_dir` describing where the file should be stored.
-The `target_dir` may include nested directories, which will be created
-automatically. Example:
+Models are listed in `config/models.yaml`. Top‑level keys may group related
+models and contain further subsections such as `diffusion_models`, `vae`, or
+`loras`. Each list entry specifies a `url` and a `target_dir` describing where
+the file should be stored. The `target_dir` may include nested directories,
+which will be created automatically. Example:
 
 ```yaml
 wan2.1:
-  - url: hf://owner/repo/path/to/model.safetensors
-    target_dir: diffusion_models/wan2.1
+  diffusion_models:
+    - url: hf://owner/repo/path/to/model.safetensors
+      target_dir: diffusion_models/wan2.1
+  vae:
+    - url: hf://owner/repo/path/to/vae.safetensors
+      target_dir: vae/wan2.1
 ```
 
 Parsing the YAML requires [PyYAML](https://pyyaml.org); the bootstrap script

--- a/config/models.yaml
+++ b/config/models.yaml
@@ -1,41 +1,53 @@
 wan2.1:
-  - url: hf://Comfy-Org/Wan_2.1_ComfyUI_repackaged/split_files/diffusion_models/wan2.1_i2v_720p_14B_fp16.safetensors
-    target_dir: diffusion_models/wan2.1
-  - url: hf://Comfy-Org/Wan_2.1_ComfyUI_repackaged/split_files/diffusion_models/wan2.1_t2v_14B_fp16.safetensors
-    target_dir: diffusion_models/wan2.1
-  - url: hf://Comfy-Org/Wan_2.1_ComfyUI_repackaged/split_files/diffusion_models/wan2.1_vace_14B_fp16.safetensors
-    target_dir: diffusion_models/wan2.1
-  - url: hf://Kijai/WanVideo_comfy/Phantom-Wan-14B_fp16.safetensors
-    target_dir: diffusion_models/wan2.1
-  - url: hf://Kijai/WanVideo_comfy/Wan2_1-VACE_module_14B_bf16.safetensors
-    target_dir: diffusion_models/wan2.1
-  - url: hf://Comfy-Org/Wan_2.1_ComfyUI_repackaged/split_files/vae/wan_2.1_vae.safetensors
-    target_dir: vae/wan2.1
+  diffusion_models:
+    - url: hf://Comfy-Org/Wan_2.1_ComfyUI_repackaged/split_files/diffusion_models/wan2.1_i2v_720p_14B_fp16.safetensors
+      target_dir: diffusion_models/wan2.1
+    - url: hf://Comfy-Org/Wan_2.1_ComfyUI_repackaged/split_files/diffusion_models/wan2.1_t2v_14B_fp16.safetensors
+      target_dir: diffusion_models/wan2.1
+    - url: hf://Comfy-Org/Wan_2.1_ComfyUI_repackaged/split_files/diffusion_models/wan2.1_vace_14B_fp16.safetensors
+      target_dir: diffusion_models/wan2.1
+    - url: hf://Kijai/WanVideo_comfy/Phantom-Wan-14B_fp16.safetensors
+      target_dir: diffusion_models/wan2.1
+    - url: hf://Kijai/WanVideo_comfy/Wan2_1-VACE_module_14B_bf16.safetensors
+      target_dir: diffusion_models/wan2.1
+  vae:
+    - url: hf://Comfy-Org/Wan_2.1_ComfyUI_repackaged/split_files/vae/wan_2.1_vae.safetensors
+      target_dir: vae/wan2.1
+
+wan2.2:
+  diffusion_models:
+    - url: hf://Comfy-Org/Wan_2.2_ComfyUI_Repackaged/split_files/diffusion_models/wan2.2_i2v_high_noise_14B_fp16.safetensors
+      target_dir: diffusion_models/wan2.2
+    - url: hf://Comfy-Org/Wan_2.2_ComfyUI_Repackaged/split_files/diffusion_models/wan2.2_i2v_low_noise_14B_fp16.safetensors
+      target_dir: diffusion_models/wan2.2
+    - url: hf://Comfy-Org/Wan_2.2_ComfyUI_Repackaged/split_files/diffusion_models/wan2.2_t2v_high_noise_14B_fp16.safetensors
+      target_dir: diffusion_models/wan2.2
+    - url: hf://Comfy-Org/Wan_2.2_ComfyUI_Repackaged/split_files/diffusion_models/wan2.2_t2v_low_noise_14B_fp16.safetensors
+      target_dir: diffusion_models/wan2.2
+  vae:
+    - url: hf://Comfy-Org/Wan_2.2_ComfyUI_Repackaged/split_files/vae/wan2.2_vae.safetensors
+      target_dir: vae/wan2.2
+  loras:
+    - url: hf://Comfy-Org/Wan_2.2_ComfyUI_Repackaged/split_files/loras/wan2.2_i2v_lightx2v_4steps_lora_v1_high_noise.safetensors
+      target_dir: loras/wan2.2
+    - url: hf://Comfy-Org/Wan_2.2_ComfyUI_Repackaged/split_files/loras/wan2.2_i2v_lightx2v_4steps_lora_v1_low_noise.safetensors
+      target_dir: loras/wan2.2
+    - url: hf://Comfy-Org/Wan_2.2_ComfyUI_Repackaged/split_files/loras/wan2.2_t2v_lightx2v_4steps_lora_v1.1_high_noise.safetensors
+      target_dir: loras/wan2.2
+    - url: hf://Comfy-Org/Wan_2.2_ComfyUI_Repackaged/split_files/loras/wan2.2_t2v_lightx2v_4steps_lora_v1.1_high_noise.safetensors
+      target_dir: loras/wan2.2
+
+text_encoders:
   - url: hf://Comfy-Org/Wan_2.1_ComfyUI_repackaged/split_files/text_encoders/umt5_xxl_fp16.safetensors
     target_dir: text_encoders
   - url: hf://Comfy-Org/Wan_2.1_ComfyUI_repackaged/split_files/text_encoders/umt5_xxl_fp8_e4m3fn_scaled.safetensors
     target_dir: text_encoders
+
+clip_vision:
   - url: hf://Comfy-Org/Wan_2.1_ComfyUI_repackaged/split_files/clip_vision/clip_vision_h.safetensors
     target_dir: clip_vision
-wan2.2:
-  - url: hf://Comfy-Org/Wan_2.2_ComfyUI_Repackaged/split_files/diffusion_models/wan2.2_i2v_high_noise_14B_fp16.safetensors
-    target_dir: diffusion_models/wan2.2
-  - url: hf://Comfy-Org/Wan_2.2_ComfyUI_Repackaged/split_files/diffusion_models/wan2.2_i2v_low_noise_14B_fp16.safetensors
-    target_dir: diffusion_models/wan2.2
-  - url: hf://Comfy-Org/Wan_2.2_ComfyUI_Repackaged/split_files/diffusion_models/wan2.2_t2v_high_noise_14B_fp16.safetensors
-    target_dir: diffusion_models/wan2.2
-  - url: hf://Comfy-Org/Wan_2.2_ComfyUI_Repackaged/split_files/diffusion_models/wan2.2_t2v_low_noise_14B_fp16.safetensors
-    target_dir: diffusion_models/wan2.2
-  - url: hf://Comfy-Org/Wan_2.2_ComfyUI_Repackaged/split_files/vae/wan2.2_vae.safetensors
-    target_dir: vae/wan2.2
-  - url: hf://Comfy-Org/Wan_2.2_ComfyUI_Repackaged/split_files/loras/wan2.2_i2v_lightx2v_4steps_lora_v1_high_noise.safetensors
-    target_dir: loras/wan2.2
-  - url: hf://Comfy-Org/Wan_2.2_ComfyUI_Repackaged/split_files/loras/wan2.2_i2v_lightx2v_4steps_lora_v1_low_noise.safetensors
-    target_dir: loras/wan2.2
-  - url: hf://Comfy-Org/Wan_2.2_ComfyUI_Repackaged/split_files/loras/wan2.2_t2v_lightx2v_4steps_lora_v1.1_high_noise.safetensors
-    target_dir: loras/wan2.2
-  - url: hf://Comfy-Org/Wan_2.2_ComfyUI_Repackaged/split_files/loras/wan2.2_t2v_lightx2v_4steps_lora_v1.1_high_noise.safetensors
-    target_dir: loras/wan2.2
-upscale:
+
+upscale_models:
   - url: hf://gemasai/4x_NMKD-Siax_200k/4x_NMKD-Siax_200k.pth
     target_dir: upscale_models
+


### PR DESCRIPTION
## Summary
- support nested model sections in `04_models.sh`
- normalize download environment variable names to underscores
- document and example nested `models.yaml`

## Testing
- `bash -n modules/04_models.sh`
- `env download_wan2_1_diffusion_models=False download_wan2_1_vae=False download_wan2_2_diffusion_models=False download_wan2_2_vae=False download_wan2_2_loras=False download_text_encoders=False download_clip_vision=False download_upscale_models=False bash modules/04_models.sh`


------
https://chatgpt.com/codex/tasks/task_e_68a1ffbaedfc832c98c89b67c53af936