### PR TITLE
Add WAN download toggles via environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,9 +20,10 @@ The command installs prerequisites, runs four modules, and then starts ComfyUI:
 1. **Jupyter** – ensures JupyterLab is available and starts it on port 8888 using `python3 -m jupyterlab`; it's monitored with a simple HTTP health check.
 2. **Workspace** – prepares persistent directories and links them with ComfyUI. The `ComfyUI/models` directory is symlinked to `/workspace/models`, avoiding duplication.
 3. **Custom nodes** – clones listed custom nodes repositories. Some plugins automatically install extra dependencies such as `sageattention` and `onnxruntime`.
-4. **Models** – downloads models defined in `config/models.yaml`. Sections can be
-   toggled with environment variables such as `download_wan2_1_diffusion_models`
-   or `download_text_encoders` set to `True`/`False`.
+4. **Models** – downloads models defined in `config/models.yaml`. The `wan2.1`
+   and `wan2.2` sections can be toggled with environment variables
+   `download_wan2.1` and `download_wan2.2` set to `True`/`False`; all other
+   sections are always downloaded.
 
 Edit `config/custom_nodes.txt` and `config/models.yaml` to customize what gets installed.
 

--- a/modules/04_models.sh
+++ b/modules/04_models.sh
@@ -100,12 +100,15 @@ PY
     mkdir -p "${MODELS_DIR}/${dir}"
   done
   while IFS=$'\t' read -r section url subdir; do
-    var_name="$(echo "download_${section}" | tr '[:upper:]' '[:lower:]' | tr -c 'a-z0-9_' '_')"
-    var_value="$(get_env "$var_name")"
-    var_value="${var_value:-True}"
-    if [ "$var_value" != "True" ]; then
-      echo "[models] skipping due to ${var_name}=${var_value}: $url"
-      continue
+    top_section="${section%%_*}"
+    if [ "$top_section" = "wan2.1" ] || [ "$top_section" = "wan2.2" ]; then
+      var_name="download_${top_section}"
+      var_value="$(get_env "$var_name")"
+      var_value="${var_value:-True}"
+      if [ "$var_value" != "True" ]; then
+        echo "[models] skipping due to ${var_name}=${var_value}: $url"
+        continue
+      fi
     fi
 
     if [[ "$url" =~ ^hf:// ]]; then


### PR DESCRIPTION
## Summary
- allow disabling WAN2.1 or WAN2.2 downloads via `download_wan2.1` and `download_wan2.2`
- document WAN environment variables

## Testing
- `env 'download_wan2.1'=False 'download_wan2.2'=False WORKDIR=/tmp/tmp.AG4CSFiSL0 bash modules/04_models.sh`


------
https://chatgpt.com/codex/tasks/task_e_68a203662820832cb0e4fd1d5a6c8c60