### PR TITLE
Launch ComfyUI to keep container running

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -70,3 +70,8 @@ run_module "04_models.sh"
 
 echo "[bootstrap] all modules started ✅"
 
+# Start ComfyUI in the foreground to keep the container alive
+echo "[bootstrap] launching ComfyUI..."
+cd "$COMFY_DIR"
+exec python main.py --listen 0.0.0.0 --port "${COMFY_PORT:-8188}"
+


### PR DESCRIPTION
## Summary
- Start ComfyUI at the end of bootstrap script so container doesn't exit after setup.

## Testing
- `bash -n start.sh`


------
https://chatgpt.com/codex/tasks/task_e_68a21bdb5c54832c9b70866f174a6e8c