### PR TITLE
Add startup scripts for ComfyUI Runpod bootstrap

### DIFF
--- a/modules/bootstrap.py
+++ b/modules/bootstrap.py
@@ -1,0 +1,25 @@
+from pathlib import Path
+import subprocess
+
+from . import custom_nodes, models
+
+
+def ensure_comfyui() -> None:
+    target = Path("/workspace/ComfyUI")
+    if target.exists():
+        return
+    subprocess.run(
+        ["git", "clone", "https://github.com/comfyanonymous/ComfyUI", str(target)],
+        check=True,
+    )
+
+
+def main() -> None:
+    ensure_comfyui()
+    custom_nodes.install_custom_nodes()
+    models.download_models()
+
+
+if __name__ == "__main__":
+    main()
+

--- a/modules/custom_nodes.py
+++ b/modules/custom_nodes.py
@@ -1,0 +1,28 @@
+from pathlib import Path
+import subprocess
+
+
+CONFIG_FILE = Path(__file__).resolve().parent.parent / "config" / "custom_nodes.txt"
+COMFY_DIR = Path("/workspace/ComfyUI")
+CUSTOM_NODES_DIR = COMFY_DIR / "custom_nodes"
+
+
+def install_custom_nodes() -> None:
+    CUSTOM_NODES_DIR.mkdir(parents=True, exist_ok=True)
+    if not CONFIG_FILE.exists():
+        return
+    with CONFIG_FILE.open() as f:
+        for line in f:
+            url = line.strip()
+            if not url or url.startswith("#"):
+                continue
+            repo_name = url.rstrip("/").split("/")[-1]
+            target = CUSTOM_NODES_DIR / repo_name
+            if target.exists():
+                continue
+            subprocess.run(["git", "clone", url, str(target)], check=True)
+
+
+if __name__ == "__main__":
+    install_custom_nodes()
+

--- a/modules/models.py
+++ b/modules/models.py
@@ -1,0 +1,79 @@
+import json
+import os
+import shutil
+from pathlib import Path
+
+import requests
+from huggingface_hub import hf_hub_download
+
+from .utils import env_true
+
+
+CONFIG_FILE = Path(__file__).resolve().parent.parent / "config" / "models.json"
+COMFY_MODELS_DIR = Path("/workspace/ComfyUI/models")
+
+
+def _download_hf(url: str, dest: Path, token: str | None) -> None:
+    repo_path = url[len("hf://") :]
+    parts = repo_path.split("/", 2)
+    repo_id = "/".join(parts[:2])
+    file_path = parts[2]
+    downloaded = hf_hub_download(repo_id=repo_id, filename=file_path, token=token)
+    shutil.copy(downloaded, dest)
+
+
+def _download_http(url: str, dest: Path, token: str | None) -> None:
+    headers = {}
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    with requests.get(url, headers=headers, stream=True) as r:
+        r.raise_for_status()
+        with open(dest, "wb") as f:
+            for chunk in r.iter_content(chunk_size=8192):
+                if chunk:
+                    f.write(chunk)
+
+
+def _download_file(item: dict) -> None:
+    url = item["url"]
+    target_dir = COMFY_MODELS_DIR / item["target_dir"]
+    target_dir.mkdir(parents=True, exist_ok=True)
+    dest = target_dir / item["rename_to"]
+    if dest.exists():
+        return
+
+    if url.startswith("hf://"):
+        _download_hf(url, dest, os.getenv("HF_KEY"))
+    else:
+        token = os.getenv("CIVITAI_KEY") if "civitai" in url.lower() else None
+        _download_http(url, dest, token)
+
+
+def _process_group(group: dict) -> None:
+    for items in group.values():
+        for item in items:
+            _download_file(item)
+
+
+def download_models() -> None:
+    if not CONFIG_FILE.exists():
+        return
+    with CONFIG_FILE.open() as f:
+        cfg = json.load(f)
+
+    if env_true("download_wan2_1"):
+        _process_group(cfg.get("wan2.1", {}))
+
+    if env_true("download_wan2_2"):
+        _process_group(cfg.get("wan2.2", {}))
+
+    for key, items in cfg.items():
+        if key in {"wan2.1", "wan2.2"}:
+            continue
+        for item in items:
+            _download_file(item)
+
+
+if __name__ == "__main__":
+    download_models()
+

--- a/modules/requirements.txt
+++ b/modules/requirements.txt
@@ -1,0 +1,2 @@
+huggingface_hub
+requests

--- a/modules/utils.py
+++ b/modules/utils.py
@@ -1,0 +1,11 @@
+import os
+
+
+def str_to_bool(value: str) -> bool:
+    """Convert common truthy strings to bool."""
+    return value.strip().lower() in {"1", "true", "yes", "y"}
+
+
+def env_true(name: str, default: str = "false") -> bool:
+    return str_to_bool(os.getenv(name, default))
+

--- a/start.sh
+++ b/start.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+WORKSPACE="/workspace"
+
+# ensure required python dependencies are available
+pip install --no-cache-dir -r "$SCRIPT_DIR/modules/requirements.txt" >/dev/null 2>&1
+
+# execute python bootstrap to install ComfyUI, custom nodes and models
+python "$SCRIPT_DIR/modules/bootstrap.py"
+


### PR DESCRIPTION
## Summary
- add `start.sh` entrypoint installing dependencies and running bootstrap
- implement Python modules to clone custom nodes and download models based on env vars
- support optional model groups WAN2.1 and WAN2.2 with HuggingFace and CivitAI tokens

## Testing
- `bash -n start.sh`
- `python -m py_compile modules/*.py`


------
https://chatgpt.com/codex/tasks/task_e_68a43d8899c0832caf71a5e5e478a274