### PR TITLE
Invoke bootstrap module in start script

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -9,5 +9,5 @@ WORKSPACE="/workspace"
 pip install --no-cache-dir -r "$SCRIPT_DIR/modules/requirements.txt" >/dev/null 2>&1
 
 # execute python bootstrap to install ComfyUI, custom nodes and models
-python "$SCRIPT_DIR/modules/bootstrap.py"
+cd "$SCRIPT_DIR" && python -m modules.bootstrap
 


### PR DESCRIPTION
## Summary
- Run bootstrap using `python -m modules.bootstrap` after changing into the script directory.
- Add empty `modules/__init__.py` for environments without namespace package support.

## Testing
- `bash -n start.sh`
- `python -m py_compile modules/__init__.py modules/bootstrap.py`


------
https://chatgpt.com/codex/tasks/task_e_68a443d90f6c832ca1797c13d12836d8