### PR TITLE
Store HuggingFace cache in workspace

### DIFF
--- a/modules/models.py
+++ b/modules/models.py
@@ -11,6 +11,8 @@ from .utils import env_true
 
 CONFIG_FILE = Path(__file__).resolve().parent.parent / "config" / "models.json"
 COMFY_MODELS_DIR = Path("/workspace/ComfyUI/models")
+HF_CACHE_DIR = Path(os.getenv("HF_HOME", "/workspace/.cache/huggingface"))
+HF_CACHE_DIR.mkdir(parents=True, exist_ok=True)
 
 
 def _download_hf(url: str, dest: Path, token: str | None) -> None:
@@ -18,7 +20,7 @@ def _download_hf(url: str, dest: Path, token: str | None) -> None:
     parts = repo_path.split("/", 2)
     repo_id = "/".join(parts[:2])
     file_path = parts[2]
-    downloaded = hf_hub_download(repo_id=repo_id, filename=file_path, token=token)
+    downloaded = hf_hub_download(repo_id=repo_id, filename=file_path, token=token, cache_dir=HF_CACHE_DIR)
     shutil.copy(downloaded, dest)
 
 

--- a/start.sh
+++ b/start.sh
@@ -5,6 +5,11 @@ set -e
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 WORKSPACE="/workspace"
 
+# store huggingface cache on persistent workspace volume
+export HF_HOME="$WORKSPACE/.cache/huggingface"
+export HF_HUB_CACHE="$HF_HOME/hub"
+mkdir -p "$HF_HUB_CACHE"
+
 # ensure required python dependencies are available
 pip install --no-cache-dir -r "$SCRIPT_DIR/modules/requirements.txt" >/dev/null 2>&1
 


### PR DESCRIPTION
## Summary
- ensure HuggingFace cache is placed on `/workspace` to avoid root disk exhaustion
- direct model downloads to use workspace cache directory

## Testing
- `bash -n start.sh`
- `python -m py_compile modules/models.py`


------
https://chatgpt.com/codex/tasks/task_e_68a445ffdbe4832c94e4eb1c03f7feff