### PR TITLE
Handle disk quota errors in model downloads

### DIFF
--- a/modules/models.py
+++ b/modules/models.py
@@ -43,12 +43,14 @@ def _download_file(item: dict) -> None:
     dest = target_dir / item["rename_to"]
     if dest.exists():
         return
-
-    if url.startswith("hf://"):
-        _download_hf(url, dest, os.getenv("HF_KEY"))
-    else:
-        token = os.getenv("CIVITAI_KEY") if "civitai" in url.lower() else None
-        _download_http(url, dest, token)
+    try:
+        if url.startswith("hf://"):
+            _download_hf(url, dest, os.getenv("HF_KEY"))
+        else:
+            token = os.getenv("CIVITAI_KEY") if "civitai" in url.lower() else None
+            _download_http(url, dest, token)
+    except OSError as e:
+        print(f"Skipping download of {url} due to error: {e}", flush=True)
 
 
 def _process_group(group: dict) -> None:


### PR DESCRIPTION
## Summary
- guard model downloads against disk quota errors so bootstrap doesn't crash repeatedly

## Testing
- `python -m py_compile modules/models.py`
- `python - <<'PY'
import modules.models as m

def fake_download(url, dest, token):
    raise OSError(122, 'Disk quota exceeded')

m._download_hf = fake_download
item = {'url': 'hf://repo/file', 'target_dir': 'test', 'rename_to': 'file'}
m._download_file(item)
PY`

------
https://chatgpt.com/codex/tasks/task_e_68a4567fbf5c832cb3e23083d1b4a9bb