### PR TITLE
Install custom node dependencies after cloning

### DIFF
--- a/modules/custom_nodes.py
+++ b/modules/custom_nodes.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 import subprocess
+import sys
 
 
 CONFIG_FILE = Path(__file__).resolve().parent.parent / "config" / "custom_nodes.txt"
@@ -22,6 +23,21 @@ def install_custom_nodes() -> None:
                 continue
             print(f"Cloning {repo_name}...", flush=True)
             subprocess.run(["git", "clone", url, str(target)], check=True)
+            requirements_files = [
+                target / "requirements.txt",
+                target / "requirements-dev.txt",
+                target / "py" / "requirements.txt",
+                target / "py" / "requirements-dev.txt",
+            ]
+            for req_file in requirements_files:
+                if req_file.exists():
+                    print(f"Installing dependencies for {repo_name}...", flush=True)
+                    subprocess.run(
+                        [sys.executable, "-m", "pip", "install", "-r", str(req_file)],
+                        check=True,
+                    )
+                    print(f"Installed dependencies for {repo_name}.", flush=True)
+                    break
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Extend custom node installer to handle dependency installation via requirements files
- Use current Python interpreter to run pip and log dependency installation

## Testing
- `python -m py_compile modules/custom_nodes.py`


------
https://chatgpt.com/codex/tasks/task_e_68a4952fe3dc832c9626565d22146056