### PR TITLE
Refactor start script to only prepare environment

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -13,10 +13,18 @@ mkdir -p "$HF_HUB_CACHE"
 # ensure required python dependencies are available
 pip install --no-cache-dir -r "$SCRIPT_DIR/modules/requirements.txt" >/dev/null 2>&1
 
-# execute python bootstrap to install ComfyUI, custom nodes and models
-cd "$SCRIPT_DIR"
-if ! python -m modules.bootstrap; then
-    echo "Bootstrap failed. Exiting." >&2
+# install ComfyUI
+if [ ! -d "$WORKSPACE/ComfyUI" ]; then
+    git clone https://github.com/comfyanonymous/ComfyUI "$WORKSPACE/ComfyUI"
 fi
+cd "$WORKSPACE/ComfyUI"
+pip install -r requirements.txt
+cd "$SCRIPT_DIR"
+
+# install custom nodes
+python -m modules.custom_nodes
+
+# download models
+python -m modules.models
 
 exit 0


### PR DESCRIPTION
## Summary
- clone ComfyUI if missing, install its requirements
- install custom nodes and download models via helper modules
- remove ComfyUI server launch from start script so RunPod command handles startup

## Testing
- `bash -n start.sh`


------
https://chatgpt.com/codex/tasks/task_e_68a4a67d1dac832ca7969495c3e41f0e