### PR TITLE
Add option to skip all model downloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,5 +19,11 @@ export WAN22_MODELS="file1.safetensors,file2.safetensors"
 If `WAN22_MODELS` is unset, all WAN 2.2 files are downloaded when
 `download_wan2_2=true`.
 
+To skip downloading any models regardless of the above flags, set:
+
+```bash
+export SKIP_MODELS_DOWNLOAD=true
+```
+
 Run `start.sh` to execute the bootstrap process.
 

--- a/modules/models.py
+++ b/modules/models.py
@@ -89,6 +89,9 @@ def _process_group(group: dict) -> bool:
 
 
 def download_models() -> None:
+    if env_true("SKIP_MODELS_DOWNLOAD"):
+        print("Skipping model downloads", flush=True)
+        return
     if not CONFIG_FILE.exists():
         return
     with CONFIG_FILE.open() as f:
@@ -96,12 +99,17 @@ def download_models() -> None:
 
     had_errors = False
 
-    if env_true("download_wan2_1"):
+    wan21_enabled = env_true("download_wan2_1")
+    wan22_enabled = env_true("download_wan2_2")
+    if not (wan21_enabled or wan22_enabled):
+        print("WAN model downloads disabled", flush=True)
+
+    if wan21_enabled:
         print("Downloading wan2.1...", flush=True)
         if not _process_group(cfg.get("wan2.1", {})):
             had_errors = True
 
-    if env_true("download_wan2_2"):
+    if wan22_enabled:
         print("Downloading wan2.2...", flush=True)
         wan22 = cfg.get("wan2.2", {})
         selected = os.getenv("WAN22_MODELS")

--- a/start.sh
+++ b/start.sh
@@ -25,6 +25,10 @@ cd "$SCRIPT_DIR"
 python -m modules.custom_nodes
 
 # download models
-python -m modules.models
+if [[ "${SKIP_MODELS_DOWNLOAD,,}" =~ ^(1|true|yes|y)$ ]]; then
+    echo "Skipping model downloads"
+else
+    python -m modules.models
+fi
 
 exit 0


### PR DESCRIPTION
## Summary
- allow disabling model downloads with `SKIP_MODELS_DOWNLOAD`
- handle case when WAN model download flags are all false
- document how to skip model downloads

## Testing
- `SKIP_MODELS_DOWNLOAD=true python -m modules.models`


------
https://chatgpt.com/codex/tasks/task_e_68ad6518c670832cbfd8b09f7c2c2de3